### PR TITLE
[Section2] 쓰레드 로컬 - ThreadLocal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	// 테스트에서 lombok 사용
+	testCompileOnly 'org.projectlombok:lombok:'
+	testAnnotationProcessor 'org.projectlombok:lombok:'
 }
 
 tasks.named('test') {

--- a/src/main/java/hello/advanced/LogTraceConfig.java
+++ b/src/main/java/hello/advanced/LogTraceConfig.java
@@ -1,0 +1,15 @@
+package hello.advanced;
+
+import hello.advanced.trace.logtrace.FieldLogTrace;
+import hello.advanced.trace.logtrace.LogTrace;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class LogTraceConfig {
+
+    @Bean
+    public LogTrace logTrace() {
+        return new FieldLogTrace();
+    }
+}

--- a/src/main/java/hello/advanced/LogTraceConfig.java
+++ b/src/main/java/hello/advanced/LogTraceConfig.java
@@ -1,7 +1,7 @@
 package hello.advanced;
 
-import hello.advanced.trace.logtrace.FieldLogTrace;
 import hello.advanced.trace.logtrace.LogTrace;
+import hello.advanced.trace.logtrace.ThreadLocalLogTrace;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -10,6 +10,6 @@ public class LogTraceConfig {
 
     @Bean
     public LogTrace logTrace() {
-        return new FieldLogTrace();
+        return new ThreadLocalLogTrace();
     }
 }

--- a/src/main/java/hello/advanced/app/v1/OrderServiceV1.java
+++ b/src/main/java/hello/advanced/app/v1/OrderServiceV1.java
@@ -15,7 +15,7 @@ public class OrderServiceV1 {
     public void orderItem(String itemId) {
         TraceStatus status = null;
         try {
-            status = trace.begin("OrderController.orderItem()");
+            status = trace.begin("OrderService.orderItem()");
             orderRepository.save(itemId);
             trace.end(status);
         } catch (Exception e) {

--- a/src/main/java/hello/advanced/app/v2/OrderServiceV2.java
+++ b/src/main/java/hello/advanced/app/v2/OrderServiceV2.java
@@ -16,7 +16,7 @@ public class OrderServiceV2 {
     public void orderItem(TraceId traceId, String itemId) {
         TraceStatus status = null;
         try {
-            status = trace.beginSync(traceId, "OrderController.orderItem()");
+            status = trace.beginSync(traceId, "OrderService.orderItem()");
             orderRepository.save(status.getTraceId(), itemId);
             trace.end(status);
         } catch (Exception e) {

--- a/src/main/java/hello/advanced/app/v3/OrderControllerV3.java
+++ b/src/main/java/hello/advanced/app/v3/OrderControllerV3.java
@@ -1,0 +1,30 @@
+package hello.advanced.app.v3;
+
+
+import hello.advanced.trace.TraceStatus;
+import hello.advanced.trace.logtrace.LogTrace;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class OrderControllerV3 {
+
+    private final OrderServiceV3 orderService;
+    private final LogTrace trace;
+
+    @GetMapping("/v3/request")
+    public String request(String itemId) {
+        TraceStatus status = null;
+        try {
+            status = trace.begin("OrderController.request()");
+            orderService.orderItem(itemId);
+            trace.end(status);
+            return "ok";
+        } catch (Exception e) {
+            trace.exception(status, e);
+            throw e; //예외를 던지지 않으면, 이 catch문에서 에러를 먹기 때문에, 비즈니스 로직의 흐름을 바꾸게 되는 것임
+        }
+    }
+}

--- a/src/main/java/hello/advanced/app/v3/OrderRepositoryV3.java
+++ b/src/main/java/hello/advanced/app/v3/OrderRepositoryV3.java
@@ -1,0 +1,39 @@
+package hello.advanced.app.v3;
+
+import hello.advanced.trace.TraceStatus;
+import hello.advanced.trace.logtrace.LogTrace;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderRepositoryV3 {
+
+    private final LogTrace trace;
+
+    public void save(String itemId)  {
+        TraceStatus status = null;
+        try {
+            status = trace.begin("OrderRepository.save()");
+
+            // 저장 로직
+            if (itemId.equals("ex")) {
+                throw new IllegalStateException("예외 발생!");
+            }
+            sleep(1000);
+
+            trace.end(status);
+        } catch (Exception e) {
+            trace.exception(status, e);
+            throw e; //예외를 던지지 않으면, 이 catch문에서 에러를 먹기 때문에, 비즈니스 로직의 흐름을 바꾸게 되는 것임
+        }
+    }
+
+    private void sleep(int millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/hello/advanced/app/v3/OrderServiceV3.java
+++ b/src/main/java/hello/advanced/app/v3/OrderServiceV3.java
@@ -1,0 +1,27 @@
+package hello.advanced.app.v3;
+
+import hello.advanced.trace.TraceStatus;
+import hello.advanced.trace.logtrace.LogTrace;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrderServiceV3 {
+
+    private final OrderRepositoryV3 orderRepository;
+    private final LogTrace trace;
+
+    public void orderItem(String itemId) {
+        TraceStatus status = null;
+        try {
+            status = trace.begin("OrderService.orderItem()");
+            orderRepository.save(itemId);
+            trace.end(status);
+        } catch (Exception e) {
+            trace.exception(status, e);
+            throw e; //예외를 던지지 않으면, 이 catch문에서 에러를 먹기 때문에, 비즈니스 로직의 흐름을 바꾸게 되는 것임
+        }
+    }
+
+}

--- a/src/main/java/hello/advanced/trace/logtrace/FieldLogTrace.java
+++ b/src/main/java/hello/advanced/trace/logtrace/FieldLogTrace.java
@@ -1,0 +1,74 @@
+package hello.advanced.trace.logtrace;
+
+import hello.advanced.trace.TraceId;
+import hello.advanced.trace.TraceStatus;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class FieldLogTrace implements LogTrace{
+
+    private static final String START_PREFIX = "-->";
+    private static final String COMPLETE_PREFIX = "<--";
+    private static final String EX_PREFIX = "<X-";
+
+    private TraceId traceIdHolder; //traceId 동기화, 동기화 이슈 발생(스프링 빈으로 등록했으니까)
+
+    @Override
+    public TraceStatus begin(String message) {
+        syncTraceId(); // 이 함수를 호출함으로써, traceIdHolder에 값이 있음을 보장
+        TraceId traceId = traceIdHolder;
+        Long startTimeMs = System.currentTimeMillis();
+        log.info("[{}] {}{}", traceId.getId(), addSpace(START_PREFIX, traceId.getLevel()), message);
+        return new TraceStatus(traceId, startTimeMs, message);
+    }
+
+    private void syncTraceId() {
+        if(traceIdHolder == null) { // 최초 호출이면
+            traceIdHolder = new TraceId(); // 새로 생성
+        } else {
+            traceIdHolder = traceIdHolder.createNextId(); // 직전 로그가 있으면, level 증가
+        }
+    }
+
+    @Override
+    public void end(TraceStatus status) {
+        complete(status, null);
+    }
+
+    @Override
+    public void exception(TraceStatus status, Exception e) {
+        complete(status, e);
+    }
+
+    private void complete(TraceStatus status, Exception e) {
+        Long stopTimeMs = System.currentTimeMillis();
+        long resultTimeMs = stopTimeMs - status.getStartTimeMs();
+        TraceId traceId = status.getTraceId();
+        if (e == null) {
+            log.info("[{}] {}{} time={}ms", traceId.getId(), addSpace(COMPLETE_PREFIX, traceId.getLevel()), status.getMessage(), resultTimeMs);
+        } else {
+            log.info("[{}] {}{} time={}ms ex={}", traceId.getId(), addSpace(EX_PREFIX, traceId.getLevel()), status.getMessage(), resultTimeMs, e.toString());
+        }
+
+        releaseTraceId();
+    }
+
+    private void releaseTraceId() {
+        if (traceIdHolder.isFirstLevel()) {
+            traceIdHolder = null;
+        } else {
+            traceIdHolder = traceIdHolder.createPreviousId();
+        }
+    }
+
+    // level=0
+    // level=1 |-->
+    // level2  |   |-->
+    private static String addSpace(String prefix, int level) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < level; i++) {
+            sb.append((i == level - 1) ? "|" + prefix : "|   ");
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/hello/advanced/trace/logtrace/FieldLogTrace.java
+++ b/src/main/java/hello/advanced/trace/logtrace/FieldLogTrace.java
@@ -12,6 +12,7 @@ public class FieldLogTrace implements LogTrace{
     private static final String EX_PREFIX = "<X-";
 
     private TraceId traceIdHolder; //traceId 동기화, 동기화 이슈 발생(스프링 빈으로 등록했으니까)
+    // 싱글톤으로 등록 == jvm에 이 객체가 딱 1개
 
     @Override
     public TraceStatus begin(String message) {

--- a/src/main/java/hello/advanced/trace/logtrace/LogTrace.java
+++ b/src/main/java/hello/advanced/trace/logtrace/LogTrace.java
@@ -1,0 +1,13 @@
+package hello.advanced.trace.logtrace;
+
+import hello.advanced.trace.TraceStatus;
+
+// 로그 추적기의 최소한의 기능을 인터페이스 화
+public interface LogTrace {
+
+    TraceStatus begin(String message);
+
+    void end(TraceStatus status);
+
+    void exception(TraceStatus status, Exception e);
+}

--- a/src/main/java/hello/advanced/trace/logtrace/ThreadLocalLogTrace.java
+++ b/src/main/java/hello/advanced/trace/logtrace/ThreadLocalLogTrace.java
@@ -1,0 +1,76 @@
+package hello.advanced.trace.logtrace;
+
+import hello.advanced.trace.TraceId;
+import hello.advanced.trace.TraceStatus;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ThreadLocalLogTrace implements LogTrace{
+
+    private static final String START_PREFIX = "-->";
+    private static final String COMPLETE_PREFIX = "<--";
+    private static final String EX_PREFIX = "<X-";
+
+    private ThreadLocal<TraceId> traceIdHolder = new ThreadLocal<>();
+
+    @Override
+    public TraceStatus begin(String message) {
+        syncTraceId(); // 이 함수를 호출함으로써, traceIdHolder에 값이 있음을 보장
+        TraceId traceId = traceIdHolder.get();
+        Long startTimeMs = System.currentTimeMillis();
+        log.info("[{}] {}{}", traceId.getId(), addSpace(START_PREFIX, traceId.getLevel()), message);
+        return new TraceStatus(traceId, startTimeMs, message);
+    }
+
+    private void syncTraceId() {
+        TraceId traceId = traceIdHolder.get();
+        if(traceId == null) { // 최초 호출이면
+            traceIdHolder.set(new TraceId()); // 새로 생성
+        } else {
+            traceIdHolder.set(traceId.createNextId()); // 직전 로그가 있으면, level 증가
+        }
+    }
+
+    @Override
+    public void end(TraceStatus status) {
+        complete(status, null);
+    }
+
+    @Override
+    public void exception(TraceStatus status, Exception e) {
+        complete(status, e);
+    }
+
+    private void complete(TraceStatus status, Exception e) {
+        Long stopTimeMs = System.currentTimeMillis();
+        long resultTimeMs = stopTimeMs - status.getStartTimeMs();
+        TraceId traceId = status.getTraceId();
+        if (e == null) {
+            log.info("[{}] {}{} time={}ms", traceId.getId(), addSpace(COMPLETE_PREFIX, traceId.getLevel()), status.getMessage(), resultTimeMs);
+        } else {
+            log.info("[{}] {}{} time={}ms ex={}", traceId.getId(), addSpace(EX_PREFIX, traceId.getLevel()), status.getMessage(), resultTimeMs, e.toString());
+        }
+
+        releaseTraceId();
+    }
+
+    private void releaseTraceId() {
+        TraceId traceId = traceIdHolder.get();
+        if (traceId.isFirstLevel()) {
+            traceIdHolder.remove(); // 이 쓰레드에서 보관한 값만 제거
+        } else {
+            traceIdHolder.set(traceId.createPreviousId());
+        }
+    }
+
+    // level=0
+    // level=1 |-->
+    // level2  |   |-->
+    private static String addSpace(String prefix, int level) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < level; i++) {
+            sb.append((i == level - 1) ? "|" + prefix : "|   ");
+        }
+        return sb.toString();
+    }
+}

--- a/src/test/java/hello/advanced/trace/logtrace/FieldLogTraceTest.java
+++ b/src/test/java/hello/advanced/trace/logtrace/FieldLogTraceTest.java
@@ -1,0 +1,27 @@
+package hello.advanced.trace.logtrace;
+
+import hello.advanced.trace.TraceStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FieldLogTraceTest {
+
+    FieldLogTrace trace = new FieldLogTrace();
+
+    @Test
+    void begin_end_level2() {
+        TraceStatus status1 = trace.begin("hello1");
+        TraceStatus status2= trace.begin("hello2");
+        trace.end(status2);
+        trace.end(status1);
+    }
+
+    @Test
+    void begin_exception_level2() {
+        TraceStatus status1 = trace.begin("hello1");
+        TraceStatus status2= trace.begin("hello2");
+        trace.exception(status2, new IllegalStateException());
+        trace.exception(status1, new IllegalStateException());
+    }
+}

--- a/src/test/java/hello/advanced/trace/logtrace/ThreadLocalLogTraceTest.java
+++ b/src/test/java/hello/advanced/trace/logtrace/ThreadLocalLogTraceTest.java
@@ -1,0 +1,25 @@
+package hello.advanced.trace.logtrace;
+
+import hello.advanced.trace.TraceStatus;
+import org.junit.jupiter.api.Test;
+
+class ThreadLocalLogTraceTest {
+
+    ThreadLocalLogTrace trace = new ThreadLocalLogTrace();
+
+    @Test
+    void begin_end_level2() {
+        TraceStatus status1 = trace.begin("hello1");
+        TraceStatus status2= trace.begin("hello2");
+        trace.end(status2);
+        trace.end(status1);
+    }
+
+    @Test
+    void begin_exception_level2() {
+        TraceStatus status1 = trace.begin("hello1");
+        TraceStatus status2= trace.begin("hello2");
+        trace.exception(status2, new IllegalStateException());
+        trace.exception(status1, new IllegalStateException());
+    }
+}

--- a/src/test/java/hello/advanced/trace/threadlocal/FieldServiceTest.java
+++ b/src/test/java/hello/advanced/trace/threadlocal/FieldServiceTest.java
@@ -1,0 +1,36 @@
+package hello.advanced.trace.threadlocal;
+
+import hello.advanced.trace.threadlocal.code.FieldService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+public class FieldServiceTest {
+
+    private FieldService fieldService = new FieldService();
+
+    @Test
+    void field() {
+        log.info("main start");
+        Thread threadA = new Thread(() -> fieldService.logic("userA"));
+        threadA.setName("thread-A");
+        Thread threadB = new Thread(() -> fieldService.logic("userB"));
+        threadB.setName("thread-B");
+
+        threadA.start();
+//        sleep(2000); // threadA가 완전히 종료되고 threadB 실행 -> 동시성 문제 발생 X
+        sleep(100); // threadA가 완전히 종료되기 전에 threadB 실행 -> 동시성 문제 발생 O
+        threadB.start();
+
+        sleep(3000); // 메인 쓰레드 종료 대기
+        log.info("main exit");
+    }
+
+    private void sleep(int millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/hello/advanced/trace/threadlocal/ThreadLocalServiceTest.java
+++ b/src/test/java/hello/advanced/trace/threadlocal/ThreadLocalServiceTest.java
@@ -1,0 +1,36 @@
+package hello.advanced.trace.threadlocal;
+
+import hello.advanced.trace.threadlocal.code.ThreadLocalService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+public class ThreadLocalServiceTest {
+
+    private ThreadLocalService service = new ThreadLocalService();
+
+    @Test
+    void thread_local() {
+        log.info("main start");
+        Thread threadA = new Thread(() -> service.logic("userA"));
+        threadA.setName("thread-A");
+        Thread threadB = new Thread(() -> service.logic("userB"));
+        threadB.setName("thread-B");
+
+        threadA.start();
+//        sleep(2000); // threadA가 완전히 종료되고 threadB 실행 -> 동시성 문제 발생 X
+        sleep(100); // threadA가 완전히 종료되기 전에 threadB 실행 -> 동시성 문제 발생 O
+        threadB.start();
+
+        sleep(3000); // 메인 쓰레드 종료 대기
+        log.info("main exit");
+    }
+
+    private void sleep(int millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/hello/advanced/trace/threadlocal/code/FieldService.java
+++ b/src/test/java/hello/advanced/trace/threadlocal/code/FieldService.java
@@ -1,0 +1,24 @@
+package hello.advanced.trace.threadlocal.code;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class FieldService {
+
+    private String nameStore;
+
+    public String logic(String name) {
+        log.info("저장 name={} -> nameStore={}", name, nameStore);
+        nameStore = name;
+        sleep(1000);
+        log.info("조회 nameStore={}", nameStore);
+        return nameStore;
+    }
+    private void sleep(int millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/hello/advanced/trace/threadlocal/code/ThreadLocalService.java
+++ b/src/test/java/hello/advanced/trace/threadlocal/code/ThreadLocalService.java
@@ -1,0 +1,24 @@
+package hello.advanced.trace.threadlocal.code;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ThreadLocalService {
+
+    private ThreadLocal<String> nameStore = new ThreadLocal<>(); // 메모리 누수가 있을 수 있음 -> remove를 통한 제거 필수
+
+    public String logic(String name) {
+        log.info("저장 name={} -> nameStore={}", name, nameStore.get());
+        nameStore.set(name);
+        sleep(1000);
+        log.info("조회 nameStore={}", nameStore.get());
+        return nameStore.get();
+    }
+    private void sleep(int millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## 학습내용
파라미터 방식의 단점을 보완해서, 필드 동기화 방식으로 수정

### 구현방식
- 필드 동기화 방식에서 동시성 이슈가 발생할 수 있는 부분 확인
  - 스프링에서는 빈으로 등록 시 싱글톤으로 동작하고 있음  
    ```
    2022-11-13 19:54:39.240  INFO 70003 --- [io-8080-exec-10] h.advanced.trace.logtrace.FieldLogTrace  : [d8bf88dd] OrderController.request()
    2022-11-13 19:54:39.241  INFO 70003 --- [io-8080-exec-10] h.advanced.trace.logtrace.FieldLogTrace  : [d8bf88dd] |-->OrderService.orderItem()
    2022-11-13 19:54:39.241  INFO 70003 --- [io-8080-exec-10] h.advanced.trace.logtrace.FieldLogTrace  : [d8bf88dd] |   |-->OrderRepository.save()
    2022-11-13 19:54:39.812  INFO 70003 --- [nio-8080-exec-1] h.advanced.trace.logtrace.FieldLogTrace  : [d8bf88dd] |   |   |-->OrderController.request()
    2022-11-13 19:54:39.813  INFO 70003 --- [nio-8080-exec-1] h.advanced.trace.logtrace.FieldLogTrace  : [d8bf88dd] |   |   |   |-->OrderService.orderItem()
    2022-11-13 19:54:39.813  INFO 70003 --- [nio-8080-exec-1] h.advanced.trace.logtrace.FieldLogTrace  : [d8bf88dd] |   |   |   |   |-->OrderRepository.save()
    2022-11-13 19:54:40.245  INFO 70003 --- [io-8080-exec-10] h.advanced.trace.logtrace.FieldLogTrace  : [d8bf88dd] |   |<--OrderRepository.save() time=1004ms
    2022-11-13 19:54:40.245  INFO 70003 --- [io-8080-exec-10] h.advanced.trace.logtrace.FieldLogTrace  : [d8bf88dd] |<--OrderService.orderItem() time=1005ms
    2022-11-13 19:54:40.246  INFO 70003 --- [io-8080-exec-10] h.advanced.trace.logtrace.FieldLogTrace  : [d8bf88dd] OrderController.request() time=1006ms
    2022-11-13 19:54:40.818  INFO 70003 --- [nio-8080-exec-1] h.advanced.trace.logtrace.FieldLogTrace  : [d8bf88dd] |   |   |   |   |<--OrderRepository.save() time=1005ms
    2022-11-13 19:54:40.818  INFO 70003 --- [nio-8080-exec-1] h.advanced.trace.logtrace.FieldLogTrace  : [d8bf88dd] |   |   |   |<--OrderService.orderItem() time=1005ms
    2022-11-13 19:54:40.818  INFO 70003 --- [nio-8080-exec-1] h.advanced.trace.logtrace.FieldLogTrace  : [d8bf88dd] |   |   |<--OrderController.request() time=1006ms
    ```
- 동시성 이슈를 해결하기 위해, `ThreadLocal` 적용
    ```
    2022-11-13 22:08:27.251  INFO 97600 --- [nio-8080-exec-2] h.a.trace.logtrace.ThreadLocalLogTrace   : [59d869f4] OrderController.request()
    2022-11-13 22:08:27.252  INFO 97600 --- [nio-8080-exec-2] h.a.trace.logtrace.ThreadLocalLogTrace   : [59d869f4] |-->OrderService.orderItem()
    2022-11-13 22:08:27.252  INFO 97600 --- [nio-8080-exec-2] h.a.trace.logtrace.ThreadLocalLogTrace   : [59d869f4] |   |-->OrderRepository.save()
    2022-11-13 22:08:27.484  INFO 97600 --- [nio-8080-exec-3] h.a.trace.logtrace.ThreadLocalLogTrace   : [9fc83b24] OrderController.request()
    2022-11-13 22:08:27.485  INFO 97600 --- [nio-8080-exec-3] h.a.trace.logtrace.ThreadLocalLogTrace   : [9fc83b24] |-->OrderService.orderItem()
    2022-11-13 22:08:27.485  INFO 97600 --- [nio-8080-exec-3] h.a.trace.logtrace.ThreadLocalLogTrace   : [9fc83b24] |   |-->OrderRepository.save()
    2022-11-13 22:08:28.255  INFO 97600 --- [nio-8080-exec-2] h.a.trace.logtrace.ThreadLocalLogTrace   : [59d869f4] |   |<--OrderRepository.save() time=1003ms
    2022-11-13 22:08:28.255  INFO 97600 --- [nio-8080-exec-2] h.a.trace.logtrace.ThreadLocalLogTrace   : [59d869f4] |<--OrderService.orderItem() time=1003ms
    2022-11-13 22:08:28.256  INFO 97600 --- [nio-8080-exec-2] h.a.trace.logtrace.ThreadLocalLogTrace   : [59d869f4] OrderController.request() time=1005ms
    2022-11-13 22:08:28.491  INFO 97600 --- [nio-8080-exec-3] h.a.trace.logtrace.ThreadLocalLogTrace   : [9fc83b24] |   |<--OrderRepository.save() time=1006ms
    2022-11-13 22:08:28.492  INFO 97600 --- [nio-8080-exec-3] h.a.trace.logtrace.ThreadLocalLogTrace   : [9fc83b24] |<--OrderService.orderItem() time=1007ms
    2022-11-13 22:08:28.492  INFO 97600 --- [nio-8080-exec-3] h.a.trace.logtrace.ThreadLocalLogTrace   : [9fc83b24] OrderController.request() time=1008ms
    ```

### 새로 알게된 점
1. ThreadLocal 사용 시, 사용이 끝나면 remove를 해줘야 함.
    - 이전에 저장한 데이터가 의도치 않게 반환될 수 있음 (심각한 비즈니스 문제 발생 가능성)